### PR TITLE
Anotar que a corretagem do BTG varia por escritório parceiro

### DIFF
--- a/pages/corretoras_exterior/btg.yml
+++ b/pages/corretoras_exterior/btg.yml
@@ -17,6 +17,7 @@ abertura:
 #   source: https://www.btgpactual.us/pt/faq
 corretagem_eua:
   text: $1 a $7,50
+  alt: "Conforme o escritório parceiro os custos de corretagem mudam. Exemplo com a AUVP: de US$20,01 até US$100 = US$1,00; até US$1.000 = US$1,25; até US$2.000 = US$2,50; acima de US$2.000 = US$3,75"
   subtext: "para ordem até $100: $1; até $1.000: $2,50; até $2.000: $5; acima: $7,50"
   source: https://www.btgpactual.us/pt/fee-schedule
 corretagem_lse: n/d


### PR DESCRIPTION
Fecha #32. Substitui o #34.

Os custos de corretagem do BTG Pactual mudam conforme o escritório parceiro, o
que a tabela não dizia — o valor exibido parecia fixo.

O texto e os números são **exatamente** os propostos pelo @gustavobrand no #34,
mantidos na redação dele, e o commit traz o `Co-authored-by`. O que ficou de fora
do #34 foi a outra metade (o `sticky top-0` no `<thead>`), que o #35 já resolveu
de forma mais completa — e que, como estava, não teria funcionado: o
`overflow-hidden` na `<table>` quebrava `position: sticky` em todos os
descendentes.

Sem `source:` porque a tabela de preços por escritório parceiro não é publicada.
O `source` que já existia continua apontando para a tabela oficial do BTG, que é
o que sustenta o valor principal da célula.

Vale notar que isto chega numa hora boa: depois do #35, o campo `alt` virou um
botão tocável e alcançável por teclado, em vez de um `title` que só aparecia no
hover. Em fevereiro esta observação seria invisível no celular.

## Verificação

- `bin/build`: 26 páginas, 0 falhas.
- A linha adicionada é idêntica à do #34, conferida com `diff`.
- Conferido em navegador: o ícone ⓘ aparece na célula do BTG em "Taxa de
  Corretagem mercado Americano", abre no clique com os valores da AUVP e fecha
  com Esc, sem erros de console.