### PR TITLE
Adicionar Webull, Revolut e ARQ

### DIFF
--- a/pages/corretoras_exterior/arq.yml
+++ b/pages/corretoras_exterior/arq.yml
@@ -1,0 +1,184 @@
+---
+nome: ARQ
+posicao: 16
+link:
+  text: ARQfinance.com
+  url: https://arqfinance.com/pt-BR
+deposito_min_abertura:
+  text: $0
+  subtext: a partir de $1 por ordem, com frações de ações
+  source: https://help.arqfinance.com/pt-BR/articles/13869170-o-que-e-o-arq-investir
+abertura:
+  text: $0
+  source: https://help.arqfinance.com/pt-BR/articles/13738316-custos-e-tarifas-no-arq
+corretagem_eua:
+  text: 0,2% (mín. 1 USDc)
+  subtext: nas contas brasileiras só a partir de 15 de setembro de 2026; até lá, $0
+  alt: A ARQ não cobra corretagem, mas cobra uma taxa de conversão de USDc para dólar de 0,2% do volume, com mínimo de 1 USDc, na compra e na venda, no plano Standard. As taxas regulatórias de SEC e FINRA são pagas pela ARQ.
+  source: https://help.arqfinance.com/pt-BR/articles/13869275-quais-taxas-se-aplicam-a-minha-conta-de-investimento
+corretagem_lse:
+  text: n/d
+  subtext: só negocia ações e ETFs listados nos EUA
+  source: https://help.arqfinance.com/pt-BR/articles/13869258-em-que-voce-pode-investir-com-a-sua-conta-de-investimentos
+deposito_eua:
+  text: $3 (ACH ou Wire)
+  subtext: da carteira USDc para a conta de investimentos é gratuito e instantâneo
+  alt: A ARQ fornece número de conta e routing próprios nos EUA. O dólar recebido é convertido automaticamente em USDc, descontados $3 por transferência.
+  source: https://help.arqfinance.com/pt-BR/articles/13901700-recarregar-minha-conta-com-dolares-usd
+saque_eua:
+  text: $3 (ACH)
+  subtext: 1 transferência internacional gratuita por mês no plano Premium
+  alt: O saque da conta de investimentos para a carteira ARQ é gratuito, mas o dinheiro da venda só fica disponível no dia útil seguinte.
+  source: https://help.arqfinance.com/pt-BR/articles/13738316-custos-e-tarifas-no-arq
+spread_brasil:
+  text: cerca de 0,5%
+  subtext: sem IOF, porque a operação é compra de USDc e não câmbio tradicional
+  alt: A ARQ não publica tabela de spread. O app mostra taxa de compra e de venda em tempo real. A própria ARQ afirma que a conversão tem custo total de aproximadamente 0,5%, sem IOF.
+  source: https://help.arqfinance.com/pt-BR/articles/15351883-desafio-arq
+acats:
+  text: entrada $0, saída n/d
+  subtext: entrada em 5 a 7 dias úteis, só ações inteiras
+  alt: A ARQ documenta apenas a transferência de entrada, dizendo que não cobra nada e que a corretora de origem pode cobrar. Não há artigo nem tabela pública sobre transferir a custódia para fora da ARQ.
+  source: https://help.arqfinance.com/pt-BR/articles/14324241-transfira-seu-portfolio-de-investimentos-para-o-arq
+inatividade:
+  text: n/d
+  alt: A ARQ não divulga taxa de inatividade. O artigo de taxas lista apenas a taxa de conversão, e a busca no help center por inatividade não retorna resultado. Ausência de menção não é o mesmo que isenção confirmada.
+  source: https://help.arqfinance.com/pt-BR/articles/13869275-quais-taxas-se-aplicam-a-minha-conta-de-investimento
+sipc:
+  text: Sim
+  subtext: $500 mil por conta, via Alpaca Securities
+  source: https://help.arqfinance.com/pt-BR/articles/13828601-como-seus-investimentos-estao-protegidos
+seguro:
+  text: Sim
+  subtext: até $75 milhões por conta e $250 milhões no agregado, no Lloyd's of London
+  alt: Seguro suplementar contratado pela Alpaca Securities. Como a SIPC, só vale em caso de insolvência da corretora, não contra perdas de mercado.
+  source: https://help.arqfinance.com/pt-BR/articles/13828601-como-seus-investimentos-estao-protegidos
+telefone:
+  text: Não
+  alt: A ARQ lista como canais oficiais apenas o chat no app e o e-mail, e alerta para golpes de falso suporte por telefone.
+  source: https://help.arqfinance.com/pt-BR/articles/14111591-canais-oficiais-do-arq
+email:
+  text: Sim
+  subtext: help@arqfinance.com
+  source: https://help.arqfinance.com/pt-BR/articles/14111591-canais-oficiais-do-arq
+chat_humano:
+  text: Sim
+  subtext: chat dentro do app
+  source: https://help.arqfinance.com/pt-BR/articles/14111591-canais-oficiais-do-arq
+horarios:
+  text: 24x7
+  source: https://help.arqfinance.com/pt-BR/articles/13610915-quem-pode-criar-uma-conta-arq
+idiomas:
+  text: Português, Espanhol, Inglês
+  source: https://help.arqfinance.com/pt-BR
+eua_acoes:
+  text: Sim
+  subtext: mais de 11 mil ações e ETFs listados nos EUA
+  source: https://help.arqfinance.com/pt-BR/articles/13869258-em-que-voce-pode-investir-com-a-sua-conta-de-investimentos
+eua_outros:
+  text: Não
+  alt: Só ações e ETFs. Não há opções, futuros nem renda fixa americana. As ordens são exclusivamente a mercado, no horário regular de Nova York, sem after-hours.
+  source: https://help.arqfinance.com/pt-BR/articles/13869310-como-comprar-e-vender-ativos
+intl_acoes:
+  text: Não
+  source: https://help.arqfinance.com/pt-BR/articles/13869258-em-que-voce-pode-investir-com-a-sua-conta-de-investimentos
+intl_outros:
+  text: Não
+  alt: A conta no exterior só dá acesso a ações e ETFs americanos. A ARQ também oferece renda fixa brasileira, mas é produto doméstico em reais, distribuído pela Genial, fora da conta na Alpaca.
+  source: https://help.arqfinance.com/pt-BR/articles/16093889-quais-ativos-de-renda-fixa-brasileiros-estao-disponiveis
+crypto:
+  text: Sim
+  subtext: 12 moedas, taxa de 0,30% no plano Standard
+  alt: Não confundir com USDc e EURc, que são apenas o trilho de dinheiro da conta. A cripto não pode ser enviada para carteiras externas e não é coberta por SIPC nem FGC.
+  source: https://help.arqfinance.com/pt-BR/articles/16648558-primeiros-passos-com-o-arq-crypto
+fracoes:
+  text: Sim
+  subtext: a partir de $1; nem todo ativo é fracionável
+  source: https://help.arqfinance.com/pt-BR/articles/13869258-em-que-voce-pode-investir-com-a-sua-conta-de-investimentos
+ach_pull:
+  text: Não
+  alt: A ARQ dá número de conta e routing nos EUA para você enviar ACH ou Wire de fora para dentro, e envia ACH para bancos americanos na saída, mas não há vínculo de conta bancária americana para a ARQ debitar.
+  source: https://help.arqfinance.com/pt-BR/articles/13901700-recarregar-minha-conta-com-dolares-usd
+cartao_debito_fisico:
+  text: Sim (Mastercard)
+  subtext: envio $4,99, grátis com saldo acima de $100 ou no plano Premium
+  alt: Entregue no Brasil. Gasta o saldo em USDc, debitado direto do saldo disponível, sem juros nem dívida acumulada.
+  source: https://help.arqfinance.com/pt-BR/articles/13549820-entendendo-a-diferenca-entre-o-cartao-global-e-local-brasil
+cartao_debito_virtual:
+  text: Sim
+  subtext: gratuito, usável na hora no Apple Pay e Google Pay
+  source: https://help.arqfinance.com/pt-BR/articles/13547335-meu-cartao-arq-tem-custos
+cartao_credito_fisico:
+  text: Sim
+  subtext: Mastercard World Elite de metal no plano Prestige, $19,99/mês
+  alt: Linha de crédito garantida pelos ativos das contas, até 90% do valor e teto de $100 mil. Sujeito a lista de espera.
+  source: https://help.arqfinance.com/pt-BR/articles/13430222-o-que-e-o-arq-prestige
+residentes_fiscais:
+  text: Brasil, México, Argentina e Colômbia
+  subtext: maiores de 18 anos
+  source: https://help.arqfinance.com/pt-BR/articles/13610915-quem-pode-criar-uma-conta-arq
+relatorio_irpf_brasil:
+  text: Sim
+  subtext: Relatório Auxiliar do Imposto de Renda, enviado por e-mail até 1º de abril
+  alt: Não é Informe de Rendimentos, que a ARQ diz não ser obrigada a emitir por não haver retenção na fonte. Cobre stablecoins, saldo em reais e os investimentos mantidos na Alpaca. A conversão pela PTAX fica por conta do investidor.
+  source: https://help.arqfinance.com/pt-BR/articles/14368060-brasil-relatorio-auxiliar-do-imposto-de-renda-dirpf-2026
+joint:
+  text: Não
+  alt: A abertura documentada é individual, com selfie, documento, questionário de adequação e W-8BEN em nome de uma única pessoa.
+  source: https://help.arqfinance.com/pt-BR/articles/13869204-como-criar-sua-conta-de-investimentos
+margin:
+  text: Não
+  alt: A conta é à vista, financiada só pelo saldo em USDc. A linha de crédito garantida dos planos pagos serve para gastar no cartão, não para comprar ativos alavancado.
+  source: https://help.arqfinance.com/pt-BR/articles/13869288-como-adicionar-fundos-na-sua-conta-de-investimentos
+offshore:
+  text: Não
+  alt: O ARQ business atende empresas sediadas no Brasil, México e Colômbia, e é conta de pagamentos, não veículo offshore.
+  source: https://arqfinance.com/pt-BR/business
+conta_bancaria:
+  text: Sim
+  subtext: conta e routing nos EUA via Lead Bank, mais IBAN em euros
+  alt: O saldo fica em USDc e EURc, que são ativos virtuais e não depósito bancário. No Brasil a conta em reais é da Atlas Brasil ARQ Instituição de Pagamento.
+  source: https://help.arqfinance.com/pt-BR/articles/13901865-como-funcionam-os-microdepositos
+conta_remunerada:
+  text: Sim
+  subtext: 2% ao ano em USDc no plano Standard, até 4,5% no Prestige
+  alt: Saldo mínimo de 150 USDc. É benefício discricionário, sem direito exigível, e não é coberto por SIPC nem FGC.
+  source: https://help.arqfinance.com/pt-BR/articles/13828751-como-funciona-sua-conta-remunerada-em-usdc
+ano_fundacao:
+  text: "2021"
+  subtext: app DolarApp lançado em 2023, marca ARQ desde março de 2026
+  source: https://www.ycombinator.com/companies/arq
+sede:
+  text: Londres, Reino Unido
+  alt: A DA Inv LLC, entidade registrada na SEC que opera o ARQ Investir, é uma LLC de Delaware com escritório principal em Londres. O grupo mantém escritórios em Nova York, São Paulo, Cidade do México, Bogotá e Buenos Aires.
+  source: https://reports.adviserinfo.sec.gov/reports/ADV/334514/PDF/334514.pdf
+funcionarios:
+  text: "100"
+  alt: Número do grupo ARQ. A DA Inv LLC, entidade do produto de investimentos, declarou 6 empregados no Formulário ADV de março de 2026.
+  source: https://www.ycombinator.com/companies/arq
+aum:
+  text: $28 milhões
+  subtext: só o ARQ Investir, em março de 2026
+  alt: Patrimônio sob gestão regulatória declarado pela DA Inv LLC no Formulário ADV. Não inclui saldos em USDc, cripto nem renda fixa brasileira.
+  source: https://reports.adviserinfo.sec.gov/reports/ADV/334514/PDF/334514.pdf
+clientes:
+  text: 2 milhões
+  subtext: no grupo ARQ, em 2026, somando todos os produtos e países
+  alt: Só na conta de investimentos, a DA Inv LLC declarou 110.459 contas no Formulário ADV de março de 2026.
+  source: https://arqfinance.com/pt-BR/blog/product-releases/announcement
+observacoes:
+- text: A distribuição de valores mobiliários a investidores brasileiros é feita pela Oslo Capital DTVM, sob o Parecer de Orientação nº 33 da CVM. Os termos deixam explícito que a empresa do app não é autorizada pela CVM a oferecer diretamente esses serviços no Brasil.
+  source: https://cdn.dolarapp.com/wealth/onboarding/oslo_terms_and_conditions_pt.pdf
+- text: A conta é aberta em nome do próprio cliente na Alpaca, não em estrutura omnibus. O cliente assina o contrato da Alpaca e o W-8BEN, e os termos preveem que a DA Inv LLC abre contas em nome do cliente e não é coproprietária delas.
+  source: https://cdn.dolarapp.com/wealth/onboarding/oslo_terms_and_conditions_pt.pdf
+- text: O dinheiro entra por Pix, é convertido em USDc e só então vai para a conta na Alpaca, que só aceita USDc. É esse desenho que dispensa o IOF de câmbio.
+  source: https://help.arqfinance.com/pt-BR/articles/13869288-como-adicionar-fundos-na-sua-conta-de-investimentos
+- text: A isenção de IOF vem de a operação ser compra de ativo virtual, e não câmbio. Vale acompanhar, porque a Resolução BCB 521 de 2025 enquadra a compra e venda de stablecoins como operação do mercado de câmbio, e os próprios termos da ARQ reconhecem que essas atividades estão sujeitas às regras cambiais, com adequação regulatória ainda em curso.
+  source: https://cdn.dolarapp.com/legal/terms-and-conditions-brazil-virtual-assets.pdf
+- text: Os termos da conta de investimentos preveem uma taxa anual sobre o patrimônio, a ser especificada num guia de serviços. Nenhuma taxa desse tipo aparece hoje na tabela pública de taxas.
+  source: https://cdn.dolarapp.com/wealth/onboarding/oslo_terms_and_conditions_pt.pdf
+- text: A migração de DolarApp para ARQ começou em março de 2026 e é gradual. Muita coisa ainda diz DolarApp, incluindo o rodapé do site, os documentos jurídicos e o site declarado à SEC.
+  source: https://help.arqfinance.com/pt-BR/articles/13897054-conheca-nossa-nova-marca-dolarapp-agora-e-arq
+
+# Finish these files with a --- (due to Frontmatter)
+---

--- a/pages/corretoras_exterior/revolut.yml
+++ b/pages/corretoras_exterior/revolut.yml
@@ -1,0 +1,178 @@
+---
+nome: Revolut
+posicao: 15
+link:
+  text: Revolut.com
+  url: https://www.revolut.com/pt-BR/
+deposito_min_abertura:
+  text: $0
+  subtext: ordem mínima de $1
+  source: https://www.revolut.com/pt-BR/legal/trading/
+abertura:
+  text: $0
+  subtext: plano Standard gratuito; planos pagos de R$9,99 a R$249,99 por mês
+  source: https://www.revolut.com/pt-BR/our-pricing-plans/
+corretagem_eua:
+  text: 1 a 10 ordens grátis/mês, depois 0,25% ou $1
+  subtext: "cota mensal por plano: Standard 1, Plus 3, Premium 5, Metal e Ultra 10; acima disso, o maior valor entre 0,25% da ordem e $1"
+  alt: A tabela cita o percentual de 0,25% apenas para Standard, Plus, Premium e Metal, sem informar qual se aplica ao Ultra. Aportes recorrentes em ETFs selecionados não pagam comissão. Não há taxa de custódia, mas taxas regulatórias dos EUA e de repasse de ADR são cobradas à parte.
+  source: https://www.revolut.com/pt-BR/legal/trading-fees-disclosure/
+corretagem_lse:
+  text: n/d
+  alt: A tabela de taxas não cita nenhuma bolsa fora dos EUA nem tarifa para o mercado de Londres.
+  source: https://www.revolut.com/pt-BR/legal/trading-fees-disclosure/
+deposito_eua:
+  text: n/d
+  alt: Não existe conta nem dados bancários nos EUA. Clientes registrados no Brasil recebem conta em reais, conta em euros com IBAN da Lituânia e dados SWIFT, sem ACH nem wire doméstico americano.
+  source: https://www.revolut.com/pt-BR/legal/localaccountdetails/
+saque_eua:
+  text: n/d
+  alt: Sem conta nos EUA não há saque doméstico americano. As saídas em moeda estrangeira saem por transferência internacional, com tarifa que varia conforme moeda e destino e é exibida no app antes de cada operação.
+  source: https://www.revolut.com/pt-BR/legal/standard-fees/
+spread_brasil:
+  text: 0% até a cota do plano, depois 1,4%
+  subtext: 1,4% de real para moeda estrangeira e 1,0% no sentido inverso
+  alt: "Cota mensal isenta por plano: R$1.000 no Standard, R$2.000 no Plus, R$4.000 no Premium, R$10.000 no Metal e R$20.000 no Ultra, somando as conversões nos dois sentidos. A cotação de real para dólar segue o Ebury Banco de Câmbio."
+  source: https://www.revolut.com/pt-BR/legal/fees/
+acats:
+  text: n/d
+  alt: A tabela de taxas não lista tarifa de transferência de custódia. Os termos mencionam a possibilidade de transferir para uma plataforma de terceiros, mas não descrevem procedimento nem preço. Frações de ações não podem ser transferidas. No encerramento, é preciso vender todas as posições em até 21 dias.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+inatividade:
+  text: $0
+  alt: A Revolut pode encerrar a conta de investimentos com aviso imediato se por seis meses ou mais não houver atividade, instrumentos ou saldo.
+  source: https://www.revolut.com/pt-BR/legal/trading-fees-disclosure/
+sipc:
+  text: Não
+  subtext: nem SIPC, nem FGC, nem qualquer outro mecanismo de reembolso
+  alt: A corretora é a Revolut Securities Singapore, licenciada pela MAS de Singapura, e não é membro da SIPC. Os termos brasileiros afirmam que os investimentos não são cobertos por nenhum mecanismo de reembolso ou pelo Fundo Garantidor de Créditos.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+seguro:
+  text: Não
+  alt: Não há apólice privada complementar. A declaração de risco da Revolut adverte que existe o risco de seus produtos de investimento não estarem protegidos caso o custodiante enfrente problemas de crédito ou venha a falir.
+  source: https://www.revolut.com/pt-BR/legal/trading-risk-disclosure/
+telefone:
+  text: Não
+  subtext: há SAC e Ouvidoria, mas a própria Revolut avisa que não conectam a um atendente
+  alt: A página de contato informa que não é possível falar com um atendente nem transferir a chamada por esses números. A linha serve para bloqueio de cartão, e o atendimento resolutivo acontece pelo chat do app.
+  source: https://www.revolut.com/pt-BR/contact-us/
+email:
+  text: Sim
+  subtext: support@revolut.com
+  source: https://www.revolut.com/pt-BR/legal/trading-fees-disclosure/
+chat_humano:
+  text: Sim
+  subtext: chat no app, canal principal de atendimento
+  source: https://www.revolut.com/pt-BR/contact-us/
+horarios:
+  text: 24x7
+  source: https://www.revolut.com/pt-BR/contact-us/
+idiomas:
+  text: Português
+  alt: O site, o app e os documentos legais estão em português, mas a plataforma de investimentos é fornecida por padrão em inglês. Os termos dizem que trocar o idioma é por conta e risco do cliente.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+eua_acoes:
+  text: Sim
+  subtext: ações e ETFs listados nos EUA, incluindo ADRs; sem venda a descoberto
+  source: https://www.revolut.com/pt-BR/legal/trading/
+eua_outros:
+  text: Não
+  subtext: só ações e ETFs; sem opções, futuros ou renda fixa
+  source: https://www.revolut.com/pt-BR/legal/trading/
+intl_acoes:
+  text: Não
+  subtext: apenas ativos listados nas bolsas americanas
+  source: https://www.revolut.com/pt-BR/legal/trading-fees-disclosure/
+intl_outros:
+  text: Não
+  source: https://www.revolut.com/pt-BR/legal/trading/
+crypto:
+  text: Sim
+  subtext: fora da conta de investimentos, pela Revolut Brasil SPSAV
+  source: https://www.revolut.com/pt-BR/our-pricing-plans/
+fracoes:
+  text: Sim
+  subtext: ordem mínima de $1
+  alt: As frações não podem ser transferidas para outra plataforma e precisam ser vendidas ao encerrar a conta. A Revolut adverte que ações fracionadas não são negociadas em mercados regulamentados e não têm valor comercial fora da plataforma.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+ach_pull:
+  text: Não
+  alt: Clientes registrados no Brasil não recebem dados de conta nos EUA, portanto não há ACH.
+  source: https://www.revolut.com/pt-BR/legal/localaccountdetails/
+cartao_debito_fisico:
+  text: Não
+  subtext: há cartão global multimoeda, mas não é de conta americana em dólar
+  alt: O cartão de débito global, da bandeira Visa, gasta a partir dos saldos em moeda estrangeira da conta Revolut e recusa transações em reais. É entregue no Brasil, mas não está ligado a uma conta bancária em dólar nos EUA nem à conta de investimentos.
+  source: https://help.revolut.com/pt-BR/help/cards/local-and-global-cards/question-brazil-which-card-to-use/
+cartao_debito_virtual:
+  text: Não
+  subtext: existe cartão virtual, mas em conta multimoeda, não em conta americana
+  source: https://www.revolut.com/pt-BR/legal/standard-fees/
+cartao_credito_fisico:
+  text: Não
+  alt: O cartão múltiplo junta crédito e débito, mas é crédito em reais concedido pela Revolut Sociedade de Crédito Direto, com fatura em reais. Não é cartão com fatura em dólar.
+  source: https://help.revolut.com/pt-BR/help/cards/local-and-global-cards/question-brazil-is-credit-card/
+residentes_fiscais:
+  text: Só Brasileiros
+  subtext: proibido para US Persons
+  source: https://www.revolut.com/pt-BR/legal/trading/
+relatorio_irpf_brasil:
+  text: Sim
+  subtext: informe de rendimentos anual
+  alt: Parte dos valores aparece na moeda original e precisa ser convertida pela cotação do último dia útil do ano. Não há documento público detalhando como a conta de investimentos aparece no informe.
+  source: https://help.revolut.com/pt-BR/help/profile-and-plan/managing-my-account/income-statement/
+joint:
+  text: Não
+  alt: A conta de investimentos nasce da conta pessoal e os termos exigem uso para benefício próprio. As contas de grupo servem para dividir despesas, não para titularidade compartilhada de ativos.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+margin:
+  text: Não
+  alt: O serviço é apenas de execução e exige fundos disponíveis antes de cada ordem. Venda a descoberto também não é aceita.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+offshore:
+  text: Não
+  source: https://www.revolut.com/pt-BR/legal/trading/
+conta_bancaria:
+  text: Não
+  subtext: conta de moeda eletrônica, não bancária
+  alt: A central de ajuda afirma que a Revolut não possui licença bancária. No Brasil, conta, Pix e crédito são da Revolut Sociedade de Crédito Direto, autorizada pelo Banco Central. Não há conta bancária americana em seu nome.
+  source: https://help.revolut.com/pt-BR/help/accounts/what-does-uk-banking-licence-with-restrictions-mean-to-my-account/is-revolut-considered-a-bank/
+conta_remunerada:
+  text: Não
+  subtext: há rendimento, mas só sobre saldo em reais
+  alt: A conta remunerada paga até 100% do CDI, ou até 120% nos planos Metal e Ultra, apenas sobre saldo em reais. Não há remuneração divulgada para o caixa em dólar da conta de investimentos.
+  source: https://www.revolut.com/pt-BR/our-pricing-plans/
+ano_fundacao:
+  text: 2015 (Reino Unido), 2021 (Brasil)
+  subtext: investimento em ações e ETFs dos EUA lançado em março de 2026
+  source: https://www.revolut.com/pt-BR/about/
+sede:
+  text: Londres, Reino Unido
+  alt: As entidades brasileiras ficam em São Paulo. A corretora que executa e custodia os investimentos, a Revolut Securities Singapore, fica em Singapura.
+  source: https://www.revolut.com/pt-BR/legal/trading-fees-disclosure/
+funcionarios:
+  text: "10.000+"
+  subtext: 2026; global
+  source: https://www.revolut.com/pt-BR/about/
+aum:
+  text: n/d
+  alt: A Revolut não divulga patrimônio sob custódia da plataforma de investimentos nem números do Brasil. O relatório anual de 2025 informa apenas saldos de clientes do grupo, que são depósitos e não custódia de valores mobiliários.
+  source: https://www.revolut.com/pt-BR/annual-report-2025/
+clientes:
+  text: 80 milhões
+  subtext: 2026; total global do grupo, não só do Brasil nem da corretora
+  source: https://www.revolut.com/pt-BR/about/
+observacoes:
+- text: Os ativos ficam em conta consolidada (omnibus), não em conta individual. Os termos dizem que os instrumentos serão registrados legalmente em nome da Revolut Securities e que seu interesse nos ativos pode não ser identificado por registros separados.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+- text: Não há SIPC, FGC nem qualquer outro fundo de reembolso. Se a corretora terceirizada que guarda os ativos ficar insolvente e faltar ativo na conta consolidada, os termos dizem que você pode não receber integralmente sua participação e poderá compartilhar o déficit com outros credores.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+- text: Quem custodia e executa é a Revolut Securities Singapore, regulada pela MAS de Singapura, que a própria Revolut declara não ter autorização da CVM. Quem responde no Brasil é a Ativa Investimentos, contratada sob o Parecer de Orientação CVM nº 33. Os documentos são regidos pela lei de Singapura.
+  source: https://www.revolut.com/pt-BR/legal/trading-fees-disclosure/
+- text: Serviço apenas de execução, sem alavancagem e sem venda a descoberto. Para encerrar a conta é preciso vender todas as posições em até 21 dias, e frações de ações não podem ser transferidas.
+  source: https://www.revolut.com/pt-BR/legal/trading/
+- text: "Reputação Ruim no Reclame Aqui: nota 5,3/10 entre fevereiro e julho de 2026, com 826 reclamações, 45,4% resolvidas e 40,3% de clientes que voltariam a fazer negócio."
+  source: https://www.reclameaqui.com.br/empresa/revolut/
+
+# Finish these files with a --- (due to Frontmatter)
+---

--- a/pages/corretoras_exterior/webull.yml
+++ b/pages/corretoras_exterior/webull.yml
@@ -1,0 +1,177 @@
+---
+nome: Webull
+posicao: 5
+link:
+  text: Webull.com.br
+  url: https://www.webull.com.br
+deposito_min_abertura:
+  text: $0
+  subtext: ordem mínima de $1 em ações e ETFs
+  alt: A Webull Financial declara no Formulário CRS que não há mínimo de conta. A conta cripto aceita depósitos a partir de $2.
+  source: https://www.webull.com.br/suporte/faq/555
+abertura:
+  text: $0
+  subtext: W-8BEN preenchido e assinado digitalmente na abertura
+  source: https://www.webull.com.br/suporte/faq/550
+corretagem_eua:
+  text: $0
+  subtext: ações, ETFs, ADRs e OTC
+  alt: Comissão de $0 em ações e ETFs listados nos EUA. Taxas regulatórias da SEC e da FINRA continuam sendo repassadas. A tabela de tarifas traz uma nota de rodapé dizendo que a isenção vale para novos clientes e que depois se aplica $0,0025 por dólar negociado, mas a nota não está ligada a nenhuma linha da tabela e a Webull não explica a qual campanha se refere.
+  source: https://www.webull.com.br/precos
+corretagem_lse:
+  text: n/d
+  subtext: não negocia bolsas fora dos EUA
+  source: https://www.webull.com.br/suporte/faq/498
+deposito_eua:
+  text: $0 (ACH), $8 (Wire EUA)
+  subtext: $12,50 no wire internacional
+  alt: Limite diário de $50 mil no ACH. Só aceita transferências de contas de mesma titularidade.
+  source: https://www.webull.com.br/precos
+saque_eua:
+  text: $0 (ACH), $25 (Wire EUA)
+  subtext: $45 no wire internacional
+  alt: A tabela de tarifas cobra $45 no saque internacional via wire, mas o FAQ sobre tarifas de ACH e Wire informa $12,50 para a mesma operação.
+  source: https://www.webull.com.br/precos
+spread_brasil:
+  text: 1,35% a 1,70%
+  subtext: cai por faixa; 0,80% acima de R$250 mil em horário comercial
+  alt: "Câmbio feito pelo Ouribank. Em horário comercial, das 9h às 18h: até R$50 mil 1,35%; até R$75 mil 1,20%; até R$250 mil 1,10%; acima disso 0,80%. Fora do horário comercial: 1,70%, 1,40%, 1,20% e 1,00% nas mesmas faixas. A conta cripto usa a FacilitaPay, com spread fixo de 1,50%. IOF de 1,1% nos depósitos e 0,38% nos resgates."
+  source: https://www.webull.com.br/precos
+acats:
+  text: entrada $0, saída $75
+  subtext: DRS $115 por posição, mais $125 se a transferência falhar
+  alt: Entrada gratuita, com valor mínimo de $500, aceitando ações, ADRs, ETFs e opções listadas nos EUA. Não aceita bonds, fundos mútuos nem penny stocks. Transferência parcial só é possível se a corretora de origem também usar a Apex, e frações de ação não são transferíveis.
+  source: https://www.webull.com.br/suporte/faq/553
+inatividade:
+  text: $0
+  source: https://www.webull.com.br/precos
+sipc:
+  text: Sim
+  subtext: $500 mil, incluindo $250 mil em dinheiro, via Webull Financial LLC
+  source: https://www.webull.com.br/suporte/faq/441
+seguro:
+  text: Sim
+  subtext: valor depende do regime de compensação, e a Webull não informa qual se aplica ao Brasil
+  alt: O documento de SIPC assinado pelo cliente brasileiro é o da modalidade Omnibus, que descreve apólice do Lloyd's of London com agregado de $100 milhões e limite de $1,9 milhão em dinheiro por cliente. Já a página institucional cita os limites do regime fully-disclosed da Apex, de $150 milhões no agregado, com máximo de $37,5 milhões em ativos e $900 mil em dinheiro por cliente.
+  source: https://www.webull.com.br/suporte/faq/441
+telefone:
+  text: Não
+  subtext: só a Ouvidoria da H.H. Picchioni, 0800 601 7100, em dias úteis
+  source: https://www.webull.com.br/suporte
+email:
+  text: Sim
+  subtext: ajuda@webull.com.br
+  source: https://www.webull.com.br/suporte
+chat_humano:
+  text: Sim
+  subtext: pela Central de Ajuda dentro do aplicativo
+  source: https://www.webull.com.br/suporte/faq/556
+horarios:
+  text: n/d
+  alt: O site se contradiz. A página institucional promete ajuda on-line 24 horas por dia, 7 dias por semana, enquanto a página da Conta Margem diz que o suporte atende em horário comercial padrão. Não há horário específico publicado para o Brasil.
+  source: https://www.webull.com.br/sobre
+idiomas:
+  text: Português
+  source: https://www.webull.com.br/suporte
+eua_acoes:
+  text: Sim
+  subtext: ações, ETFs, ADRs, OTC e IPOs; sem fundos mútuos
+  source: https://www.webull.com.br/suporte/faq/495
+eua_outros:
+  text: Sim
+  subtext: opções, futuros CME e contratos de eventos; sem renda fixa
+  alt: Opções de ações e ETFs sem corretagem, $0,50 por contrato em opções de índice e $0,10 por contrato em ordens acima de 500 contratos, fora as taxas de cada bolsa. Futuros e contratos de eventos são oferecidos pela Webull Futures LLC e não são protegidos pela SIPC.
+  source: https://www.webull.com.br/precos
+intl_acoes:
+  text: Não
+  subtext: só ADRs de empresas estrangeiras listados nos EUA
+  source: https://www.webull.com.br/suporte/faq/498
+intl_outros:
+  text: Não
+  source: https://www.webull.com.br/suporte/faq/498
+crypto:
+  text: Sim
+  subtext: sem corretagem, com spread embutido no preço
+  alt: Oferecido pela Webull SPSAV em conta separada da conta de investimentos, com execução, liquidação e custódia feitas pela Coinbase. A Webull SPSAV ainda não é autorizada em regime definitivo pelo Banco Central, estando em período de transição regulatória. O câmbio da conta cripto é feito pela FacilitaPay, com spread de 1,50%.
+  source: https://www.webull.com.br/investimento-negociacao/cripto
+fracoes:
+  text: Sim
+  subtext: a partir de $1 e 0,01 ação
+  alt: Disponível apenas em ativos marcados com o ícone F, no horário regular de mercado. Não permite venda a descoberto e as frações não entram no empréstimo de ações.
+  source: https://www.webull.com.br/suporte/faq/505
+ach_pull:
+  text: Sim
+  subtext: conta americana de mesma titularidade, vinculada via Plaid ou microdepósitos
+  source: https://www.webull.com.br/suporte/faq/444
+cartao_debito_fisico:
+  text: n/d
+  subtext: previsto em contrato, mas não anunciado
+  alt: Os contratos brasileiros trazem um Contrato de Conta Corrente do Stearns Bank que prevê cartão de débito Mastercard, com 1ª via grátis e $20 de envio internacional. Mesmo assim não há página, item de menu nem FAQ sobre esse cartão, e não foi possível confirmar que ele já é emitido e entregue no Brasil.
+  source: https://www.webull.com.br/agreement
+cartao_debito_virtual: n/d
+cartao_credito_fisico: Não
+residentes_fiscais:
+  text: Só Brasileiros
+  subtext: exige endereço no Brasil, CPF e 18 anos ou mais
+  source: https://www.webull.com.br/suporte/faq/555
+relatorio_irpf_brasil:
+  text: Sim
+  alt: A Webull anuncia relatórios de IR para facilitar a declaração de investimentos no exterior. No site, a documentação descrita é o extrato mensal, com saldos convertidos pela PTAX, e as notas de negociação.
+  source: https://www.webull.com.br/suporte
+joint:
+  text: Não
+  alt: A Webull aceita apenas contas individuais, atreladas a um CPF. Depósitos e saques de terceiros ou de pessoa jurídica são rejeitados.
+  source: https://www.webull.com.br/suporte/faq/557
+margin:
+  text: Sim
+  subtext: 4x intradiário e 2x overnight, com mínimo de $2.000 de patrimônio
+  alt: A taxa de juros é escalonada por saldo devedor e só aparece dentro do aplicativo. A Webull informa que a taxa é variável e pode mudar sem aviso.
+  source: https://www.webull.com.br/conta-margem
+offshore:
+  text: Não
+  source: https://www.webull.com.br/suporte/faq/559
+conta_bancaria:
+  text: n/d
+  subtext: contratos preveem conta corrente no Stearns Bank, mas ela não é anunciada
+  alt: A Conta Webull em reais, usada para receber PIX e fazer o câmbio, é uma conta-câmbio no Ouribank, não uma conta bancária. Os contratos brasileiros trazem separadamente um Contrato de Conta Corrente do Stearns Bank, membro do FDIC, que não aparece em nenhuma página do site.
+  source: https://www.webull.com.br/agreement
+conta_remunerada:
+  text: Sim
+  subtext: 3% ao ano sobre o caixa livre
+  alt: O caixa liquidado é varrido para bancos parceiros após 2 dias úteis, ficando elegível ao seguro FDIC de $250 mil por banco. Precisa ser ativado pelo cliente. A taxa é dinâmica, e a Webull cita 3% ao ano em um artigo e até 4% em outro.
+  source: https://www.webull.com.br/suporte/faq/531
+ano_fundacao:
+  text: 2018
+  subtext: início da corretora nos EUA
+  source: https://www.sec.gov/Archives/edgar/data/1866364/000121390026041653/ea0283691-20f_webull.htm
+sede:
+  text: St. Petersburg, FL, EUA
+  subtext: escritório brasileiro na Av. Brigadeiro Faria Lima, São Paulo
+  source: https://www.sec.gov/Archives/edgar/data/1866364/000121390026041653/ea0283691-20f_webull.htm
+funcionarios:
+  text: "1.396"
+  subtext: dez/2025, grupo Webull global
+  source: https://www.sec.gov/Archives/edgar/data/1866364/000121390026041653/ea0283691-20f_webull.htm
+aum:
+  text: $28,5 bilhões
+  subtext: 2T26, ativos de clientes do grupo global, não só do Brasil
+  source: https://www.sec.gov/Archives/edgar/data/1866364/000121390026091702/ea030257601ex99-1.htm
+clientes:
+  text: 5,13 milhões
+  subtext: 2T26, contas com saldo do grupo global
+  alt: A Webull não divulga separadamente o número de clientes brasileiros.
+  source: https://www.sec.gov/Archives/edgar/data/1866364/000121390026091702/ea030257601ex99-1.htm
+observacoes:
+- text: A oferta é intermediada pela H.H. Picchioni CCVM, corretora autorizada pelo BCB e pela CVM, nos termos do Parecer de Orientação CVM nº 33. A corretora americana é a Webull Financial LLC, que não tem autorização da CVM.
+  source: https://www.webull.com.br/suporte
+- text: A compra da H.H. Picchioni pela Webull foi assinada em dezembro de 2023, mas ainda não foi concluída. O fechamento depende de aprovação incondicional do Banco Central, e no formulário 20-F de abril de 2026 a Webull diz esperar concluir até o fim de 2026.
+  source: https://www.sec.gov/Archives/edgar/data/1866364/000121390026041653/ea0283691-20f_webull.htm
+- text: Usa a plataforma da Apex, em regime de compensação omnibus. Todos os contratos assinados pelo cliente brasileiro são da modalidade Omnibus.
+  source: https://www.webull.com.br/agreement
+- text: O câmbio é feito pelo Ouribank, com a Webull Technologies Brazil atuando como correspondente cambial. A conta-câmbio em reais é aberta em nome do cliente no Ouribank.
+  source: https://www.webull.com.br/suporte
+- text: A Webull Corporation é listada na Nasdaq sob o código BULL.
+  source: https://www.sec.gov/Archives/edgar/data/1866364/000121390026091702/ea030257601ex99-1.htm
+
+# Finish these files with a --- (due to Frontmatter)
+---

--- a/pages/stylesheets/application.css.scss
+++ b/pages/stylesheets/application.css.scss
@@ -51,7 +51,10 @@ html:not(.js) .js-only {
   .cc-table:has(tbody td:nth-child(8):not([colspan]):hover) :is(thead th, tbody td):nth-child(8):not([colspan]),
   .cc-table:has(tbody td:nth-child(9):not([colspan]):hover) :is(thead th, tbody td):nth-child(9):not([colspan]),
   .cc-table:has(tbody td:nth-child(10):not([colspan]):hover) :is(thead th, tbody td):nth-child(10):not([colspan]),
-  .cc-table:has(tbody td:nth-child(11):not([colspan]):hover) :is(thead th, tbody td):nth-child(11):not([colspan]) {
+  .cc-table:has(tbody td:nth-child(11):not([colspan]):hover) :is(thead th, tbody td):nth-child(11):not([colspan]),
+  .cc-table:has(tbody td:nth-child(12):not([colspan]):hover) :is(thead th, tbody td):nth-child(12):not([colspan]),
+  .cc-table:has(tbody td:nth-child(13):not([colspan]):hover) :is(thead th, tbody td):nth-child(13):not([colspan]),
+  .cc-table:has(tbody td:nth-child(14):not([colspan]):hover) :is(thead th, tbody td):nth-child(14):not([colspan]) {
     background-color: var(--cc-column);
   }
 


### PR DESCRIPTION
Três corretoras que passaram a atender residentes fiscais brasileiros desde a
última revisão da lista. Cada perfil saiu das páginas oficiais e dos contratos de
cada uma, e o que não deu para confirmar ficou como `n/d` com explicação no
campo. A **Webull** é corretora americana membro FINRA/SIPC intermediada pela
H.H. Picchioni CCVM, com corretagem zero, e a compra da Picchioni ainda depende
de aprovação do Banco Central. A **ARQ** (ex-DolarApp) abre conta na Alpaca em
nome do próprio cliente, com SIPC e seguro do Lloyds, e o trilho via USDc hoje
dispensa o IOF, embora a Resolução BCB 521/2025 trate stablecoin como operação de
câmbio e a adequação siga em curso. A **Revolut** é o caso que mais destoa: os
ativos ficam em conta consolidada registrada em nome da corretora em Singapura, e
os próprios termos dizem que os investimentos não são cobertos por nenhum
mecanismo de reembolso nem pelo FGC, e que num default o cliente pode dividir o
déficit com os demais credores.

A **Wise não entra**: a tabela de elegibilidade da própria Wise lista o Brasil só
com "Interest", sem "Stocks". O único produto investível aqui é o Rende+, um
fundo de mercado monetário comprado e vendido automaticamente conforme o cliente
gasta no cartão, sem conta de corretagem, sem escolha de ativo e sem SIPC. **Rico
e Clear** também não, por serem a mesma Conta Investimento Global da XP
International, já registrada nas observações da XP. A tabela vai a 13 corretoras,
com 834 strings conferidas no HTML gerado e as suítes de interação, navegação por
seção e sem-JavaScript passando.